### PR TITLE
Add JRuby extension to the gem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby
+      engine: cruby-jruby
       min_version: 2.5
 
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 *.bundle
 *.dll
 *.so
+lib/nkf.jar
+.idea
+nkf.iml

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,18 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("nkf")
+if RUBY_ENGINE == "jruby"
+  require "rake/javaextensiontask"
+  Rake::JavaExtensionTask.new("nkf") do |ext|
+    ext.source_version = "1.8"
+    ext.target_version = "1.8"
+    ext.ext_dir = "ext/java"
+  end
+
+  task :build => :compile
+else
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new("nkf")
+end
+
 task :default => :test

--- a/ext/java/org/jruby/ext/nkf/Command.java
+++ b/ext/java/org/jruby/ext/nkf/Command.java
@@ -1,0 +1,59 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.nkf;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class Command {
+    private final List<Option> options = new ArrayList<Option>();
+    public boolean hasOption(String opt) {
+        for (Option option : options) {
+            if (opt.equals(option.getOpt())) return true;
+            if (opt.equals(option.getLongOpt())) return true;
+        }
+        return false;
+    }
+    public void addOption(Option opt) {
+        options.add(opt);
+    }
+    public Option getOption(String opt) {
+        for (Option option : options) {
+            if (opt.equals(option.getOpt())) return option;
+            if (opt.equals(option.getLongOpt())) return option;
+        }
+        return null;
+    }
+    public String getOptionValue(String opt) {
+        return getOption(opt).getValue();
+    }
+    public String toString() {
+        return options.toString();
+    }
+}

--- a/ext/java/org/jruby/ext/nkf/Command.java
+++ b/ext/java/org/jruby/ext/nkf/Command.java
@@ -1,5 +1,5 @@
 /***** BEGIN LICENSE BLOCK *****
- * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ * Version: EPL 2.0/LGPL 2.1
  *
  * The contents of this file are subject to the Eclipse Public
  * License Version 2.0 (the "License"); you may not use this file
@@ -14,16 +14,15 @@
  * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
  *
  * Alternatively, the contents of this file may be used under the terms of
- * either of the GNU General Public License Version 2 or later (the "GPL"),
- * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the LGPL are applicable instead
  * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
+ * under the terms of either the LGPL, and not to allow others to
  * use your version of this file under the terms of the EPL, indicate your
  * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
+ * and other provisions required by the LGPL. If you do not delete
  * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the EPL, the GPL or the LGPL.
+ * the terms of any one of the EPL, the LGPL.
  ***** END LICENSE BLOCK *****/
 
 package org.jruby.ext.nkf;

--- a/ext/java/org/jruby/ext/nkf/CommandParser.java
+++ b/ext/java/org/jruby/ext/nkf/CommandParser.java
@@ -1,0 +1,71 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.nkf;
+
+public class CommandParser {
+    public Command parse(Options opt, String args) {
+        Command cc = new Command();
+        String[] tokens = args.split("\\s");
+        for (int i = 0; i < tokens.length; i++) {
+            // long option
+            if (tokens[i].startsWith("--")) {
+                String s = stripDash(tokens[i]);
+                if (opt.hasLongOption(s)) {
+                    cc.addOption(opt.matchLongOption(s));
+                }
+            } else {
+                // short option
+                String s = stripDash(tokens[i]);
+                int max = s.length();
+                for (int j = 0; j < max; j++) {
+                    if (opt.hasShortOption(s)) {
+                        Option cmd = opt.matchShortOption(s);
+                        if (cmd.getValue() != null) {
+                            int op_len = cmd.getValue().length();
+                            s = s.substring(op_len);
+                            j = j + op_len;
+                        }
+                        cc.addOption(cmd);
+                    }
+                    s = s.substring(1);
+                }
+            }
+        }
+        return cc;
+    }
+    private String stripDash(String s) {
+        if (s.startsWith("--")) {
+            return s.substring(2, s.length());
+        } else if (s.startsWith("-")) {
+            return s.substring(1, s.length());
+        } else {
+            return s;
+        }
+    }
+}

--- a/ext/java/org/jruby/ext/nkf/CommandParser.java
+++ b/ext/java/org/jruby/ext/nkf/CommandParser.java
@@ -1,5 +1,5 @@
 /***** BEGIN LICENSE BLOCK *****
- * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ * Version: EPL 2.0/LGPL 2.1
  *
  * The contents of this file are subject to the Eclipse Public
  * License Version 2.0 (the "License"); you may not use this file
@@ -14,16 +14,15 @@
  * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
  *
  * Alternatively, the contents of this file may be used under the terms of
- * either of the GNU General Public License Version 2 or later (the "GPL"),
- * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the LGPL are applicable instead
  * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
+ * under the terms of either the LGPL, and not to allow others to
  * use your version of this file under the terms of the EPL, indicate your
  * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
+ * and other provisions required by the LGPL. If you do not delete
  * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the EPL, the GPL or the LGPL.
+ * the terms of any one of the EPL, the LGPL.
  ***** END LICENSE BLOCK *****/
 
 package org.jruby.ext.nkf;

--- a/ext/java/org/jruby/ext/nkf/NKFLibrary.java
+++ b/ext/java/org/jruby/ext/nkf/NKFLibrary.java
@@ -1,0 +1,13 @@
+package org.jruby.ext.nkf;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.load.Library;
+
+import java.io.IOException;
+
+public class NKFLibrary implements Library {
+    @Override
+    public void load(Ruby ruby, boolean b) throws IOException {
+        RubyNKF.load(ruby);
+    }
+}

--- a/ext/java/org/jruby/ext/nkf/Option.java
+++ b/ext/java/org/jruby/ext/nkf/Option.java
@@ -1,0 +1,81 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.nkf;
+
+import java.util.regex.Pattern;
+
+public class Option {
+    private final String opt;
+    private final String longOpt;
+    private boolean hasArg = false;
+    private String value = null;
+    private Pattern pattern;
+
+    public Option(String opt, String longOpt, String pattern) {
+        this.opt = opt;
+        this.longOpt = longOpt;
+        if (pattern != null) {
+            this.hasArg = true;
+            this.pattern = Pattern.compile(pattern);
+        }
+    }
+    String getOpt() { return opt; }
+    String getLongOpt() { return longOpt; }
+    boolean hasShortOpt() {
+        return opt != null;
+    }
+    boolean hasLongOpt() {
+        return longOpt != null;
+    }
+    boolean hasArg() {
+        return hasArg;
+    }
+    public String getValue() {
+        return value;
+    }
+    void setValue(String v) {
+        value = v;
+    }
+    String getKey() {
+        if (opt == null)
+            return longOpt;
+        else
+            return opt;
+    }
+    Pattern pattern() {
+        return pattern;
+    }
+    public String toString() {
+        return "[opt: " + opt
+            + " longOpt: " + longOpt
+            + " hasArg: " + hasArg
+            + " pattern: " + pattern
+            + " value: " + value + "]";
+    }
+}

--- a/ext/java/org/jruby/ext/nkf/Option.java
+++ b/ext/java/org/jruby/ext/nkf/Option.java
@@ -1,5 +1,5 @@
 /***** BEGIN LICENSE BLOCK *****
- * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ * Version: EPL 2.0/LGPL 2.1
  *
  * The contents of this file are subject to the Eclipse Public
  * License Version 2.0 (the "License"); you may not use this file
@@ -14,16 +14,15 @@
  * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
  *
  * Alternatively, the contents of this file may be used under the terms of
- * either of the GNU General Public License Version 2 or later (the "GPL"),
- * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the LGPL are applicable instead
  * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
+ * under the terms of either the LGPL, and not to allow others to
  * use your version of this file under the terms of the EPL, indicate your
  * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
+ * and other provisions required by the LGPL. If you do not delete
  * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the EPL, the GPL or the LGPL.
+ * the terms of any one of the EPL, the LGPL.
  ***** END LICENSE BLOCK *****/
 
 package org.jruby.ext.nkf;

--- a/ext/java/org/jruby/ext/nkf/Options.java
+++ b/ext/java/org/jruby/ext/nkf/Options.java
@@ -1,0 +1,110 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.nkf;
+
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.regex.Matcher;
+
+public class Options {
+    private final Map<String, Option> shortOpts = new LinkedHashMap<String, Option>();
+    private final Map<String, Option> longOpts = new LinkedHashMap<String, Option>();
+
+    public Options addOption(String opt) {
+        return addOption(opt, null);
+    }
+    public Options addOption(String opt, String longOpt) {
+        return addOption(opt, longOpt, null);
+    }
+    public Options addOption(String opt, String longOpt, String pattern) {
+        return addOption(new Option(opt, longOpt, pattern));
+    }
+    public Options addOption(Option opt) {
+        if (opt.hasLongOpt()) {
+            longOpts.put(opt.getLongOpt(), opt);
+        }
+        if (opt.hasShortOpt()) {
+            shortOpts.put(opt.getOpt(), opt);
+        }
+        return this;
+    }
+    boolean hasShortOption(String opt) {
+        for (Map.Entry<String , Option> e : shortOpts.entrySet()) {
+            if (opt.startsWith(e.getKey())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    public Option matchShortOption(String opt) {
+        // independent of opt length
+        for (Map.Entry<String , Option> e : shortOpts.entrySet()) {
+            //System.out.println(opt + " = " + e.getKey());
+            if (opt.startsWith(e.getKey())) {
+                //System.out.println("match[" + e.getKey() + "]");
+                Option cmd = e.getValue();
+                if (cmd.hasArg()) {
+                    Matcher m = cmd.pattern().matcher(opt);
+                    if (m.find()) {
+                        //System.out.println("regix[" + m.group() + "]");
+                        cmd.setValue(m.group());
+                    }
+                }
+                return cmd;
+            }
+        }
+        return null;
+    }
+    boolean hasLongOption(String opt) {
+        for (Map.Entry<String , Option> e : longOpts.entrySet()) {
+            if (opt.startsWith(e.getKey())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    Option matchLongOption(String opt) {
+        for (Map.Entry<String , Option> e : longOpts.entrySet()) {
+            //System.out.println(opt + " = " + e.getKey());
+            if (opt.startsWith(e.getKey())) {
+                //System.out.println("match[" + e.getKey() + "]");
+                Option cmd = e.getValue();
+                if (cmd.hasArg()) {
+                    Matcher m = cmd.pattern().matcher(opt);
+                    if (m.find()) {
+                        //System.out.println("regix[" + m.group() + "]");
+                        cmd.setValue(m.group(1));
+                    }
+                }
+                return cmd;
+            }
+        }
+        return null;
+    }
+}

--- a/ext/java/org/jruby/ext/nkf/Options.java
+++ b/ext/java/org/jruby/ext/nkf/Options.java
@@ -1,5 +1,5 @@
 /***** BEGIN LICENSE BLOCK *****
- * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ * Version: EPL 2.0/LGPL 2.1
  *
  * The contents of this file are subject to the Eclipse Public
  * License Version 2.0 (the "License"); you may not use this file
@@ -14,16 +14,15 @@
  * Copyright (C) 2011 Koichiro Ohba <koichiro@meadowy.org>
  *
  * Alternatively, the contents of this file may be used under the terms of
- * either of the GNU General Public License Version 2 or later (the "GPL"),
- * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the LGPL are applicable instead
  * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
+ * under the terms of either the LGPL, and not to allow others to
  * use your version of this file under the terms of the EPL, indicate your
  * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
+ * and other provisions required by the LGPL. If you do not delete
  * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the EPL, the GPL or the LGPL.
+ * the terms of any one of the EPL, the LGPL.
  ***** END LICENSE BLOCK *****/
 
 package org.jruby.ext.nkf;

--- a/ext/java/org/jruby/ext/nkf/RubyNKF.java
+++ b/ext/java/org/jruby/ext/nkf/RubyNKF.java
@@ -532,9 +532,9 @@ public class RubyNKF {
             String[] mime = str.split("^=\\?|\\?|\\?=$");
             String charset = detectCharset(mime[1]);
             int encode = mime[2].charAt(0);
-            ByteList body = new ByteList(mime[3].getBytes(), ASCIIEncoding.INSTANCE);
+            RubyString body = EncodingUtils.newExternalStringWithEncoding(context.runtime, mime[3], ASCIIEncoding.INSTANCE);
 
-            final RubyArray array;
+            final RubyArray<?> array;
             if ('B' == encode || 'b' == encode) { // BASE64
                 array = Pack.unpack(context, body, PACK_BASE64);
             } else { // Qencode

--- a/ext/java/org/jruby/ext/nkf/RubyNKF.java
+++ b/ext/java/org/jruby/ext/nkf/RubyNKF.java
@@ -1,0 +1,602 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2007-2011 Koichiro Ohba <koichiro@meadowy.org>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.nkf;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.jcodings.Encoding;
+import org.jcodings.specific.ASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
+import org.jcodings.transcode.EConv;
+import org.jcodings.transcode.EConvFlags;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyModule;
+import org.jruby.RubyString;
+
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+import org.jruby.util.KCode;
+import org.jruby.util.Pack;
+import org.jruby.util.io.EncodingUtils;
+
+@JRubyModule(name="NKF")
+public class RubyNKF {
+    public static enum NKFCharset {
+        AUTO(0, "x-JISAutoDetect"),
+        // no ISO-2022-JP in jcodings
+        JIS(1, "ISO-2022-JP"),
+        EUC(2, "EUC-JP"),
+        SJIS(3, "Shift_JIS"),
+        BINARY(4, null),
+        NOCONV(4, null),
+        UNKNOWN(0, null),
+        ASCII(5, "iso-8859-1"),
+        UTF8(6, "UTF-8"),
+        UTF16(8, "UTF-16"),
+        UTF32(12, "UTF-32"),
+        OTHER(16, null),
+        BASE64(20, "base64"),
+        QENCODE(21, "qencode"),
+        MIME_DETECT(22, "MimeAutoDetect");
+
+        private NKFCharset(int value, String charset) {
+            this.value = value;
+            this.charset = charset;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public String getCharset() {
+            return charset;
+        }
+
+        private final int value;
+        private final String charset;
+    }
+
+    private static final ByteList BEGIN_MIME_STRING = new ByteList(ByteList.plain("=?"));
+    private static final ByteList END_MIME_STRING = new ByteList(ByteList.plain("?="));
+    private static final ByteList PACK_BASE64 = new ByteList(ByteList.plain("m"));
+    private static final ByteList PACK_QENCODE = new ByteList(ByteList.plain("M"));
+
+    public static final Map<Integer, String> NKFCharsetMap = new HashMap<Integer, String>(20, 1);
+
+    public static void load(Ruby runtime) {
+        createNKF(runtime);
+    }
+
+    public static void createNKF(Ruby runtime) {
+        final RubyModule NKF = runtime.defineModule("NKF");
+        final String version = "2.1.2";
+        final String relDate = "2011-09-08";
+
+        NKF.defineConstant("NKF_VERSION", runtime.newString(version));
+        NKF.defineConstant("NKF_RELEASE_DATE", runtime.newString(relDate));
+        NKF.defineConstant("VERSION", runtime.newString(version + ' ' + '(' + "JRuby" + '_' + relDate + ')'));
+
+        for ( NKFCharset charset : NKFCharset.values() ) {
+            NKFCharsetMap.put(charset.value, charset.name());
+
+            if (charset.value > 12 ) continue;
+            NKF.defineConstant(charset.name(), charsetMappedValue(runtime, charset));
+        }
+
+        NKF.defineAnnotatedMethods(RubyNKF.class);
+    }
+
+    @JRubyMethod(name = "guess", module = true)
+    public static IRubyObject guess(ThreadContext context, IRubyObject recv, IRubyObject s) {
+        return charsetMappedValue(context.runtime, guess(context, s));
+    }
+
+    public static NKFCharset guess(ThreadContext context, IRubyObject s) {
+        // TODO: Fix charset usage for JRUBY-4553
+        Ruby runtime = context.runtime;
+        if (!s.respondsTo("to_str")) {
+            throw runtime.newTypeError("can't convert " + s.getMetaClass() + " into String");
+        }
+        ByteList bytes = s.convertToString().getByteList();
+        ByteBuffer buf = ByteBuffer.wrap(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
+        CharsetDecoder decoder;
+        try {
+            decoder = Charset.forName("x-JISAutoDetect").newDecoder();
+        } catch (UnsupportedCharsetException e) {
+            throw runtime.newStandardError("charsets.jar is required to use NKF#guess. Please install JRE which supports m17n.");
+        }
+        try {
+            decoder.decode(buf);
+
+            if ( ! decoder.isCharsetDetected() ) {
+                return NKFCharset.UNKNOWN;
+            }
+            Charset charset = decoder.detectedCharset();
+            String name = charset.name();
+            if ("Shift_JIS".equals(name)) {
+                return NKFCharset.SJIS;
+            }
+            if ("Windows-31j".equalsIgnoreCase(name)) {
+                return NKFCharset.JIS;
+            }
+            if ("EUC-JP".equals(name)) {
+                return NKFCharset.EUC;
+            }
+            if ("ISO-2022-JP".equals(name)) {
+                return NKFCharset.JIS;
+            }
+        }
+        catch (CharacterCodingException e) {
+            // fall through and try direct encoding
+        }
+
+        if (bytes.getEncoding() == UTF8Encoding.INSTANCE) {
+            return NKFCharset.UTF8;
+        }
+        if (bytes.getEncoding().toString().startsWith("UTF-16")) {
+            return NKFCharset.UTF16;
+        }
+        if (bytes.getEncoding().toString().startsWith("UTF-32")) {
+            return NKFCharset.UTF32;
+        }
+        return NKFCharset.UNKNOWN;
+    }
+
+    private static IRubyObject charsetMappedValue(final Ruby runtime, final NKFCharset charset) {
+        final Encoding encoding;
+        switch (charset) {
+            case AUTO: case NOCONV: case UNKNOWN: return runtime.getNil();
+            case BINARY:
+                encoding = runtime.getEncodingService().getAscii8bitEncoding();
+                return runtime.getEncodingService().convertEncodingToRubyEncoding(encoding);
+        }
+
+        encoding = runtime.getEncodingService().getEncodingFromString(charset.getCharset());
+        return runtime.getEncodingService().convertEncodingToRubyEncoding(encoding);
+    }
+
+    @JRubyMethod(name = "guess1", module = true)
+    public static IRubyObject guess1(ThreadContext context, IRubyObject recv, IRubyObject str) {
+        return guess(context, recv, str);
+    }
+
+    @JRubyMethod(name = "guess2", module = true)
+    public static IRubyObject guess2(ThreadContext context, IRubyObject recv, IRubyObject str) {
+        return guess(context, recv, str);
+    }
+
+    @JRubyMethod(name = "nkf", module = true)
+    public static IRubyObject nkf(ThreadContext context, IRubyObject recv, IRubyObject opt, IRubyObject str) {
+        Ruby runtime = context.runtime;
+
+        if (!opt.respondsTo("to_str")) {
+            throw runtime.newTypeError("can't convert " + opt.getMetaClass() + " into String");
+        }
+
+        if (!str.respondsTo("to_str")) {
+            throw runtime.newTypeError("can't convert " + str.getMetaClass() + " into String");
+        }
+
+        Map<String, NKFCharset> options = parseOpt(opt.convertToString().toString());
+
+        if (options.get("input").getValue() == NKFCharset.AUTO.getValue()) {
+            options.put("input", guess(context, str));
+        }
+
+        ByteList bstr = str.convertToString().getByteList();
+        final Converter converter;
+        if (Converter.isMimeText(bstr, options)) {
+            converter = new MimeConverter(context, options);
+        } else {
+            converter = new DefaultConverter(context, options);
+        }
+
+        RubyString result = converter.convert(bstr);
+
+        if (options.get("mime-encode") == NKFCharset.BASE64) {
+            result = Converter.encodeMimeString(runtime, result, PACK_BASE64);
+        } else if (options.get("mime-encode") == NKFCharset.QENCODE) {
+            result = Converter.encodeMimeString(runtime, result, PACK_QENCODE);
+        }
+
+        return result;
+    }
+
+    public static Command parseOption(String s) {
+        Options options = new Options();
+        options.addOption("b");
+        options.addOption("u");
+        options.addOption("j", "jis");
+        options.addOption("s", "sjis");
+        options.addOption("e", "euc");
+        options.addOption("w", null, "[0-9][0-9]");
+        options.addOption("J", "jis-input");
+        options.addOption("S", "sjis-input");
+        options.addOption("E", "euc-input");
+        options.addOption("W", null, "[0-9][0-9]");
+        options.addOption("t");
+        options.addOption("i_");
+        options.addOption("o_");
+        options.addOption("r");
+        options.addOption("h1", "hiragana");
+        options.addOption("h2", "katakana");
+        options.addOption("h3", "katakana-hiragana");
+        options.addOption("T");
+        options.addOption("l");
+        options.addOption("f", null, "[0-9]+-[0-9]*");
+        options.addOption("F");
+        options.addOption("Z", null, "[0-3]");
+        options.addOption("X");
+        options.addOption("x");
+        options.addOption("B", null, "[0-2]");
+        options.addOption("I");
+        options.addOption("L", null, "[uwm]");
+        options.addOption("d");
+        options.addOption("c");
+        options.addOption("m", null, "[BQN0]");
+        options.addOption("M", null, "[BQ]");
+        options.addOption(null, "fj");
+        options.addOption(null, "unix");
+        options.addOption(null, "mac");
+        options.addOption(null, "msdos");
+        options.addOption(null, "windows");
+        options.addOption(null, "mime");
+        options.addOption(null, "base64");
+        options.addOption(null, "mime-input");
+        options.addOption(null, "base64-input");
+        options.addOption(null, "ic", "ic=(.*)");
+        options.addOption(null, "oc", "oc=(.*)");
+        options.addOption(null, "fb-skip");
+        options.addOption(null, "fb-html");
+        options.addOption(null, "fb-xml");
+        options.addOption(null, "fb-perl");
+        options.addOption(null, "fb-java");
+        options.addOption(null, "fb-subchar", "fb-subchar=(.*)");
+        options.addOption(null, "no-cp932ext");
+        options.addOption(null, "cap-input");
+        options.addOption(null, "url-input");
+        options.addOption(null, "numchar-input");
+        options.addOption(null, "no-best-fit-chars");
+
+        CommandParser parser = new CommandParser();
+        Command cmd = parser.parse(options, s);
+        return cmd;
+    }
+
+    private static Map<String, NKFCharset> parseOpt(String s) {
+        Map<String, NKFCharset> options = new HashMap<String, NKFCharset>();
+
+        // default options
+        options.put("input", NKFCharset.AUTO);
+        options.put("output", NKFCharset.JIS);
+        options.put("mime-decode", NKFCharset.MIME_DETECT);
+        options.put("mime-encode", NKFCharset.NOCONV);
+
+        Command cmd = parseOption(s);
+        if (cmd.hasOption("j")) {
+            options.put("output", NKFCharset.JIS);
+        }
+        if (cmd.hasOption("s")) {
+            options.put("output", NKFCharset.SJIS);
+        }
+        if (cmd.hasOption("e")) {
+            options.put("output", NKFCharset.EUC);
+        }
+        if (cmd.hasOption("w")) {
+            Option opt = cmd.getOption("w");
+            if ("32".equals(opt.getValue())) {
+                options.put("output", NKFCharset.UTF32);
+            } else if("16".equals(opt.getValue())) {
+                options.put("output", NKFCharset.UTF16);
+            } else {
+                options.put("output", NKFCharset.UTF8);
+            }
+        }
+        if (cmd.hasOption("J")) {
+            options.put("input", NKFCharset.JIS);
+        }
+        if (cmd.hasOption("S")) {
+            options.put("input", NKFCharset.SJIS);
+        }
+        if (cmd.hasOption("E")) {
+            options.put("input", NKFCharset.EUC);
+        }
+        if (cmd.hasOption("W")) {
+            Option opt = cmd.getOption("W");
+            if ("32".equals(opt.getValue())) {
+                options.put("input", NKFCharset.UTF32);
+            } else if("16".equals(opt.getValue())) {
+                options.put("input", NKFCharset.UTF16);
+            } else {
+                options.put("input", NKFCharset.UTF8);
+            }
+        }
+        if (cmd.hasOption("m")) {
+            Option opt = cmd.getOption("m");
+            if (opt.getValue() == null) {
+                options.put("mime-decode", NKFCharset.MIME_DETECT);
+            } else if ("B".equals(opt.getValue())) {
+                options.put("mime-decode", NKFCharset.BASE64);
+            } else if ("Q".equals(opt.getValue())) {
+                options.put("mime-decode", NKFCharset.QENCODE);
+            } else if ("N".equals(opt.getValue())) {
+                // TODO: non-strict option
+            } else if ("0".equals(opt.getValue())) {
+                options.put("mime-decode", NKFCharset.NOCONV);
+            }
+        }
+        if (cmd.hasOption("M")) {
+            Option opt = cmd.getOption("M");
+            if (opt.getValue() == null) {
+                options.put("mime-encode", NKFCharset.NOCONV);
+            } else if ("B".equals(opt.getValue())) {
+                options.put("mime-encode", NKFCharset.BASE64);
+            } else if ("Q".equals(opt.getValue())) {
+                options.put("mime-encode", NKFCharset.QENCODE);
+            }
+        }
+        if (cmd.hasOption("base64")) {
+            options.put("mime-encode", NKFCharset.BASE64);
+        }
+        if (cmd.hasOption("oc")) {
+            Option opt = cmd.getOption("oc");
+            if ("ISO-2022-JP".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.JIS);
+            } else if ("EUC-JP".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.EUC);
+            } else if ("CP932".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.SJIS);
+            } else if ("Shift_JIS".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.SJIS);
+            } else if ("Windows-31J".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.JIS);
+            } else if ("UTF-8".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF8);
+            } else if ("UTF-8N".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF8);
+            } else if ("UTF-16".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF16);
+            } else if ("UTF-16BE-BOM".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF16);
+            } else if ("UTF-32".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF32);
+            } else if ("UTF-32BE-BOM".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("output", NKFCharset.UTF32);
+            }
+        }
+        if (cmd.hasOption("ic")) {
+            Option opt = cmd.getOption("ic");
+            if ("ISO-2022-JP".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.JIS);
+            } else if ("EUC-JP".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.EUC);
+            } else if ("CP932".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.SJIS);
+            } else if ("Shift_JIS".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.SJIS);
+            } else if ("Windows-31J".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.SJIS);
+            } else if ("UTF-8".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF8);
+            } else if ("UTF-8N".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF8);
+            } else if ("UTF-16".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF16);
+            } else if ("UTF-16BE-BOM".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF16);
+            } else if ("UTF-32".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF32);
+            } else if ("UTF-32BE-BOM".compareToIgnoreCase(opt.getValue()) == 0) {
+                options.put("input", NKFCharset.UTF32);
+            }
+        }
+
+        return options;
+    }
+
+    static abstract class Converter {
+
+        protected final ThreadContext context;
+        protected final Map<String, NKFCharset> options;
+
+        public Converter(ThreadContext ctx, Map<String, NKFCharset> opt) {
+            context = ctx;
+            options = opt;
+        }
+
+        static boolean isMimeText(ByteList str, Map<String, NKFCharset> options) {
+            if (str.length() <= 6) {
+                return false;
+            }
+            if (options.get("mime-decode") == NKFCharset.NOCONV) {
+                return false;
+            }
+            if (str.indexOf(BEGIN_MIME_STRING) < 0) {
+                return false;
+            }
+            if (str.lastIndexOf(END_MIME_STRING) < 0) {
+                return false;
+            }
+            return true;
+        }
+
+        private static RubyString encodeMimeString(Ruby runtime, RubyString str, ByteList format) {
+            RubyArray array = RubyArray.newArray(runtime, str);
+            return Pack.pack(runtime, array, format).chomp(runtime.getCurrentContext());
+        }
+
+        abstract RubyString convert(ByteList str);
+
+        ByteList convert_byte(ByteList str, String inputCharset, NKFCharset output) {
+            String outputCharset = output.getCharset();
+
+            if (inputCharset == null) {
+                inputCharset = str.getEncoding().toString();
+            }
+
+            if (outputCharset.equals(inputCharset)) {
+                return str.dup();
+            }
+
+            byte[] outCharsetBytes = outputCharset.getBytes();
+
+            EConv ec = EncodingUtils.econvOpenOpts(context, inputCharset.getBytes(), outCharsetBytes, 0, context.nil);
+
+            if (ec == null) {
+                throw context.runtime.newArgumentError("invalid encoding pair: " + inputCharset + " to " + outputCharset);
+            }
+
+            ByteList converted = EncodingUtils.econvStrConvert(context, ec, str, EConvFlags.INVALID_REPLACE);
+
+            converted.setEncoding(context.runtime.getEncodingService().findEncodingOrAliasEntry(outCharsetBytes).getEncoding());
+
+            return converted;
+        }
+    }
+
+    static class DefaultConverter extends Converter {
+
+        public DefaultConverter(ThreadContext ctx, Map<String, NKFCharset> opt) {
+            super(ctx, opt);
+        }
+
+        RubyString convert(ByteList str) {
+            NKFCharset input = options.get("input");
+            NKFCharset output = options.get("output");
+            ByteList b = convert_byte(str,
+                    input.getCharset(),
+                    output);
+            return context.runtime.newString(b);
+        }
+    }
+
+    static class MimeConverter extends Converter {
+
+        public MimeConverter(ThreadContext ctx, Map<String, NKFCharset> opt) {
+            super(ctx, opt);
+        }
+
+        private String detectCharset(String charset) {
+            if (charset.compareToIgnoreCase(NKFCharset.UTF8.getCharset()) == 0) {
+                return NKFCharset.UTF8.getCharset();
+            } else if (charset.compareToIgnoreCase(NKFCharset.JIS.getCharset()) == 0) {
+                return NKFCharset.JIS.getCharset();
+            } else if (charset.compareToIgnoreCase(NKFCharset.EUC.getCharset()) == 0) {
+                return NKFCharset.EUC.getCharset();
+            } else {
+                return NKFCharset.ASCII.getCharset();
+            }
+        }
+
+        private ByteList decodeMimeString(String str) {
+            String[] mime = str.split("^=\\?|\\?|\\?=$");
+            String charset = detectCharset(mime[1]);
+            int encode = mime[2].charAt(0);
+            ByteList body = new ByteList(mime[3].getBytes(), ASCIIEncoding.INSTANCE);
+
+            final RubyArray array;
+            if ('B' == encode || 'b' == encode) { // BASE64
+                array = Pack.unpack(context, body, PACK_BASE64);
+            } else { // Qencode
+                array = Pack.unpack(context, body, PACK_QENCODE);
+            }
+            RubyString s = (RubyString) array.entry(0);
+            ByteList decodeStr = s.asString().getByteList();
+
+            return convert_byte(decodeStr, charset, options.get("output"));
+        }
+
+        RubyString makeRubyString(ArrayList<ByteList> list) {
+            ByteList r = new ByteList();
+            for (ByteList l : list) {
+                r.append(l);
+            }
+            return context.runtime.newString(r);
+        }
+
+        RubyString convert(ByteList str) {
+            String s = Helpers.decodeByteList(context.runtime, str);
+            String[] token = s.split("\\s");
+            ArrayList<ByteList> raw_data = new ArrayList<ByteList>();
+
+            for (int i = 0; i < token.length; i++) {
+                raw_data.add(decodeMimeString(token[i]));
+            }
+
+            return makeRubyString(raw_data);
+        }
+
+    }
+
+    @Deprecated
+    public static final NKFCharset AUTO = NKFCharset.AUTO;
+    // no ISO-2022-JP in jcodings
+    @Deprecated
+    public static final NKFCharset JIS = NKFCharset.JIS;
+    @Deprecated
+    public static final NKFCharset EUC = NKFCharset.EUC;
+    @Deprecated
+    public static final NKFCharset SJIS = NKFCharset.SJIS;
+    @Deprecated
+    public static final NKFCharset BINARY = NKFCharset.BINARY;
+    @Deprecated
+    public static final NKFCharset NOCONV = NKFCharset.NOCONV;
+    @Deprecated
+    public static final NKFCharset UNKNOWN = NKFCharset.UNKNOWN;
+    @Deprecated
+    public static final NKFCharset ASCII = NKFCharset.ASCII;
+    @Deprecated
+    public static final NKFCharset UTF8 = NKFCharset.UTF8;
+    @Deprecated
+    public static final NKFCharset UTF16 = NKFCharset.UTF16;
+    @Deprecated
+    public static final NKFCharset UTF32 = NKFCharset.UTF32;
+    @Deprecated
+    public static final NKFCharset OTHER = NKFCharset.OTHER;
+    @Deprecated
+    public static final NKFCharset BASE64 = NKFCharset.BASE64;
+    @Deprecated
+    public static final NKFCharset QENCODE = NKFCharset.QENCODE;
+    @Deprecated
+    public static final NKFCharset MIME_DETECT = NKFCharset.MIME_DETECT;
+}

--- a/ext/java/org/jruby/ext/nkf/RubyNKF.java
+++ b/ext/java/org/jruby/ext/nkf/RubyNKF.java
@@ -1,5 +1,5 @@
 /***** BEGIN LICENSE BLOCK *****
- * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ * Version: EPL 2.0/LGPL 2.1
  *
  * The contents of this file are subject to the Eclipse Public
  * License Version 2.0 (the "License"); you may not use this file
@@ -14,16 +14,15 @@
  * Copyright (C) 2007-2011 Koichiro Ohba <koichiro@meadowy.org>
  *
  * Alternatively, the contents of this file may be used under the terms of
- * either of the GNU General Public License Version 2 or later (the "GPL"),
- * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the LGPL are applicable instead
  * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
+ * under the terms of either the LGPL, and not to allow others to
  * use your version of this file under the terms of the EPL, indicate your
  * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
+ * and other provisions required by the LGPL. If you do not delete
  * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the EPL, the GPL or the LGPL.
+ * the terms of any one of the EPL, the LGPL.
  ***** END LICENSE BLOCK *****/
 
 package org.jruby.ext.nkf;

--- a/lib/nkf.rb
+++ b/lib/nkf.rb
@@ -1,0 +1,6 @@
+if RUBY_ENGINE == "jruby"
+  require 'nkf.jar'
+  JRuby::Util.load_ext('org.jruby.ext.nkf.NKFLibrary')
+else
+  require 'nkf.so'
+end

--- a/nkf.gemspec
+++ b/nkf.gemspec
@@ -11,8 +11,8 @@ end
 Gem::Specification.new do |spec|
   spec.name          = "nkf"
   spec.version       = source_version
-  spec.authors       = ["NARUSE Yui"]
-  spec.email         = ["naruse@airemix.jp"]
+  spec.authors       = ["NARUSE Yui", "Charles Oliver Nutter"]
+  spec.email         = ["naruse@airemix.jp", "headius@headius.com"]
 
   spec.summary       = %q{Ruby extension for Network Kanji Filter}
   spec.description   = %q{Ruby extension for Network Kanji Filter}
@@ -28,8 +28,16 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
+
+  if Gem::Platform === spec.platform and spec.platform =~ 'java' or RUBY_ENGINE == 'jruby'
+    spec.platform = 'java'
+
+    spec.files += Dir["lib/nkf.jar"]
+  else
+    spec.extensions    = ["ext/nkf/extconf.rb"]
+  end
+
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions    = ["ext/nkf/extconf.rb"]
 end

--- a/nkf.gemspec
+++ b/nkf.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   if Gem::Platform === spec.platform and spec.platform =~ 'java' or RUBY_ENGINE == 'jruby'
     spec.platform = 'java'
-
+    spec.licenses      += ["EPL-2.0", "LGPL-2.1"]
     spec.files += Dir["lib/nkf.jar"]
   else
     spec.extensions    = ["ext/nkf/extconf.rb"]


### PR DESCRIPTION
This pulls in the nkf extension implementation from JRuby. The build and load logic has been updated along the same lines as ruby/digest and the gem appears to build correctly for the -java platform.

Fixes #13