### PR TITLE
Add changelog_uri for rubygems.org

### DIFF
--- a/nkf.gemspec
+++ b/nkf.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This PR added [changelog_uri](https://guides.rubygems.org/specification-reference/#metadata) for [rubygems.org](https://rubygems.org/gems/nkf)