### PR TITLE
Add RBS signature and testing

### DIFF
--- a/.github/workflows/sig.yml
+++ b/.github/workflows/sig.yml
@@ -1,0 +1,18 @@
+name: sig
+
+on: [push, pull_request]
+
+jobs:
+  sig:
+    runs-on: "ubuntu-latest"
+    env:
+      BUNDLE_WITH: sig
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+      - name: Run RBS test
+        run: bundle exec rake rbs:test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           - ruby: 2.5
             os: macos-latest
     runs-on: ${{ matrix.os }}
+    env:
+      BUNDLE_WITHOUT: sig
     steps:
     - uses: actions/checkout@v6
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,12 @@
 source "https://rubygems.org"
 
+gemspec
+
 gem "rake"
 gem "rake-compiler"
 gem "test-unit"
+
+group :sig do
+  gem "rbs"
+  gem "rdoc"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,25 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
+namespace :rbs do
+  Rake::TestTask.new(test: :compile) do |t|
+    t.libs << "test_sig"
+    t.ruby_opts << "-rtest_helper"
+    t.test_files = FileList["test_sig/test_*.rb"]
+    t.warning = true
+  end
+
+  desc 'Update RBS comments'
+  task :annotate do
+    require "tmpdir"
+
+    Dir.mktmpdir do |tmpdir|
+      sh("rdoc --ri --output #{tmpdir}/doc --root=. lib")
+      sh("rbs annotate --no-system --no-gems --no-site --no-home -d #{tmpdir}/doc sig")
+    end
+  end
+end
+
 if RUBY_ENGINE == "jruby"
   require "rake/javaextensiontask"
   Rake::JavaExtensionTask.new("nkf") do |ext|

--- a/sig/kconv.rbs
+++ b/sig/kconv.rbs
@@ -1,0 +1,166 @@
+# <!-- rdoc-file=lib/kconv.rb -->
+# Kanji Converter for Ruby.
+#
+module Kconv
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # ASCII
+  #
+  ASCII: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # Auto-Detect
+  #
+  AUTO: nil
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # BINARY
+  #
+  BINARY: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # EUC-JP
+  #
+  EUC: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # ISO-2022-JP
+  #
+  JIS: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # NOCONV
+  #
+  NOCONV: nil
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # Shift_JIS
+  #
+  SJIS: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # UNKNOWN
+  #
+  UNKNOWN: nil
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # UTF-16
+  #
+  UTF16: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # UTF-32
+  #
+  UTF32: Encoding
+
+  # <!-- rdoc-file=lib/kconv.rb -->
+  # UTF-8
+  #
+  UTF8: Encoding
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.guess(str)   => encoding
+  # -->
+  # Guess input encoding by NKF.guess
+  #
+  def self.guess: (String str) -> Encoding
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.iseuc(str)   => true or false
+  # -->
+  # Returns whether input encoding is EUC-JP or not.
+  #
+  # **Note** don't expect this return value is MatchData.
+  #
+  def self.iseuc: (String str) -> bool
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.isjis(str)   => true or false
+  # -->
+  # Returns whether input encoding is ISO-2022-JP or not.
+  #
+  def self.isjis: (String str) -> bool
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.issjis(str)   => true or false
+  # -->
+  # Returns whether input encoding is Shift_JIS or not.
+  #
+  def self.issjis: (String str) -> bool
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.isutf8(str)   => true or false
+  # -->
+  # Returns whether input encoding is UTF-8 or not.
+  #
+  def self.isutf8: (String str) -> bool
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.kconv(str, to_enc, from_enc=nil)
+  # -->
+  # Convert `str` to `to_enc`. `to_enc` and `from_enc` are given as constants of
+  # Kconv or Encoding objects.
+  #
+  def self.kconv: (String str, Encoding? out_code, ?Encoding? in_code) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.toeuc(str)   => string
+  # -->
+  # Convert `str` to EUC-JP
+  #
+  def self.toeuc: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.tojis(str)   => string
+  # -->
+  # Convert `str` to ISO-2022-JP
+  #
+  def self.tojis: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.tolocale   => string
+  # -->
+  # Convert `self` to locale encoding
+  #
+  def self.tolocale: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.tosjis(str)   => string
+  # -->
+  # Convert `str` to Shift_JIS
+  #
+  def self.tosjis: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.toutf16(str)   => string
+  # -->
+  # Convert `str` to UTF-16
+  #
+  def self.toutf16: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.toutf32(str)   => string
+  # -->
+  # Convert `str` to UTF-32
+  #
+  def self.toutf32: (String str) -> String
+
+  # <!--
+  #   rdoc-file=lib/kconv.rb
+  #   - Kconv.toutf8(str)   => string
+  # -->
+  # Convert `str` to UTF-8
+  #
+  def self.toutf8: (String str) -> String
+end

--- a/sig/nkf.rbs
+++ b/sig/nkf.rbs
@@ -1,0 +1,404 @@
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# NKF - Ruby extension for Network Kanji Filter
+#
+# ## Description
+#
+# This is a Ruby Extension version of nkf (Network Kanji Filter). It converts
+# the first argument and returns converted result. Conversion details are
+# specified by flags as the first argument.
+#
+# **Nkf** is a yet another kanji code converter among networks, hosts and
+# terminals. It converts input kanji code to designated kanji code such as
+# ISO-2022-JP, Shift_JIS, EUC-JP, UTF-8 or UTF-16.
+#
+# One of the most unique faculty of **nkf** is the guess of the input kanji
+# encodings. It currently recognizes ISO-2022-JP, Shift_JIS, EUC-JP, UTF-8 and
+# UTF-16. So users needn't set the input kanji code explicitly.
+#
+# By default, X0201 kana is converted into X0208 kana. For X0201 kana, SO/SI,
+# SSO and ESC-(-I methods are supported. For automatic code detection, nkf
+# assumes no X0201 kana in Shift_JIS. To accept X0201 in Shift_JIS, use **-X**,
+# **-x** or **-S**.
+#
+# ## Flags
+#
+# ### -b -u
+#
+# Output is buffered (DEFAULT), Output is unbuffered.
+#
+# ### -j -s -e -w -w16 -w32
+#
+# Output code is ISO-2022-JP (7bit JIS), Shift_JIS, EUC-JP, UTF-8N, UTF-16BE,
+# UTF-32BE. Without this option and compile option, ISO-2022-JP is assumed.
+#
+# ### -J -S -E -W -W16 -W32
+#
+# Input assumption is JIS 7 bit, Shift_JIS, EUC-JP, UTF-8, UTF-16, UTF-32.
+#
+# #### -J
+#
+# Assume  JIS input. It also accepts EUC-JP. This is the default. This flag does
+# not exclude Shift_JIS.
+#
+# #### -S
+#
+# Assume Shift_JIS and X0201 kana input. It also accepts JIS. EUC-JP is
+# recognized as X0201 kana. Without **-x** flag, X0201 kana (halfwidth kana) is
+# converted into X0208.
+#
+# #### -E
+#
+# Assume EUC-JP input. It also accepts JIS. Same as -J.
+#
+# ### -t
+#
+# No conversion.
+#
+# ### -i_
+#
+# Output sequence to designate JIS-kanji. (DEFAULT B)
+#
+# ### -o_
+#
+# Output sequence to designate ASCII. (DEFAULT B)
+#
+# ### -r
+#
+# {de/en}crypt ROT13/47
+#
+# ### -h[123] --hiragana --katakana --katakana-hiragana
+#
+# -h1 --hiragana
+# :   Katakana to Hiragana conversion.
+#
+#
+# -h2 --katakana
+# :   Hiragana to Katakana conversion.
+#
+#
+# -h3 --katakana-hiragana
+# :   Katakana to Hiragana and Hiragana to Katakana conversion.
+#
+#
+# ### -T
+#
+# Text mode output (MS-DOS)
+#
+# ### -l
+#
+# ISO8859-1 (Latin-1) support
+#
+# ### -f[`m` [- `n`]]
+#
+# Folding on `m` length with `n` margin in a line. Without this option, fold
+# length is 60 and fold margin is 10.
+#
+# ### -F
+#
+# New line preserving line folding.
+#
+# ### -Z[0-3]
+#
+# Convert X0208 alphabet (Fullwidth Alphabets) to ASCII.
+#
+# -Z -Z0
+# :   Convert X0208 alphabet to ASCII.
+#
+#
+# -Z1
+# :   Converts X0208 kankaku to single ASCII space.
+#
+#
+# -Z2
+# :   Converts X0208 kankaku to double ASCII spaces.
+#
+#
+# -Z3
+# :   Replacing Fullwidth >, <, ", & into '&gt;', '&lt;', '&quot;', '&amp;' as
+#     in HTML.
+#
+#
+# ### -X -x
+#
+# Assume X0201 kana in MS-Kanji. With **-X** or without this option, X0201 is
+# converted into X0208 Kana. With **-x**, try to preserve X0208 kana and do not
+# convert X0201 kana to X0208. In JIS output, ESC-(-I is used. In EUC output,
+# SSO is used.
+#
+# ### -B[0-2]
+#
+# Assume broken JIS-Kanji input, which lost ESC. Useful when your site is using
+# old B-News Nihongo patch.
+#
+# -B1
+# :   allows any char after ESC-( or ESC-$.
+#
+#
+# -B2
+# :   forces ASCII after NL.
+#
+#
+# ### -I
+#
+# Replacing non iso-2022-jp char into a geta character (substitute character in
+# Japanese).
+#
+# ### -d -c
+#
+# Delete r in line feed, Add r in line feed.
+#
+# ### -m[BQN0]
+#
+# MIME ISO-2022-JP/ISO8859-1 decode. (DEFAULT) To see ISO8859-1 (Latin-1) -l is
+# necessary.
+#
+# -mB
+# :   Decode MIME base64 encoded stream. Remove header or other part before
+#
+# conversion.
+#
+# -mQ
+# :   Decode MIME quoted stream. '_' in quoted stream is converted to space.
+#
+#
+# -mN
+# :   Non-strict decoding.
+#
+# It allows line break in the middle of the base64 encoding.
+#
+# -m0
+# :   No MIME decode.
+#
+#
+# ### -M
+#
+# MIME encode. Header style. All ASCII code and control characters are intact.
+# Kanji conversion is performed before encoding, so this cannot be used as a
+# picture encoder.
+#
+# -MB
+# :   MIME encode Base64 stream.
+#
+#
+# -MQ
+# :   Perform quoted encoding.
+#
+#
+# ### -l
+#
+# Input and output code is ISO8859-1 (Latin-1) and ISO-2022-JP. **-s**, **-e**
+# and **-x** are not compatible with this option.
+#
+# ### -L[uwm]
+#
+# new line mode Without this option, nkf doesn't convert line breaks.
+#
+# -Lu
+# :   unix (LF)
+#
+#
+# -Lw
+# :   windows (CRLF)
+#
+#
+# -Lm
+# :   mac (CR)
+#
+#
+# ### --fj --unix --mac --msdos --windows
+#
+# convert for these system
+#
+# ### --jis --euc --sjis --mime --base64
+#
+# convert for named code
+#
+# ### --jis-input --euc-input --sjis-input --mime-input --base64-input
+#
+# assume input system
+#
+# ### --ic=`input codeset` --oc=`output codeset`
+#
+# Set the input or output codeset. NKF supports following codesets and those
+# codeset name are case insensitive.
+#
+# ISO-2022-JP
+# :   a.k.a. RFC1468, 7bit JIS, JUNET
+#
+#
+# EUC-JP (eucJP-nkf)
+# :   a.k.a. AT&T JIS, Japanese EUC, UJIS
+#
+#
+# eucJP-ascii
+# :   a.k.a. x-eucjp-open-19970715-ascii
+#
+#
+# eucJP-ms
+# :   a.k.a. x-eucjp-open-19970715-ms
+#
+#
+# CP51932
+# :   Microsoft Version of EUC-JP.
+#
+#
+# Shift_JIS
+# :   SJIS, MS-Kanji
+#
+#
+# Windows-31J
+# :   a.k.a. CP932
+#
+#
+# UTF-8
+# :   same as UTF-8N
+#
+#
+# UTF-8N
+# :   UTF-8 without BOM
+#
+#
+# UTF-8-BOM
+# :   UTF-8 with BOM
+#
+#
+# UTF-16
+# :   same as UTF-16BE
+#
+#
+# UTF-16BE
+# :   UTF-16 Big Endian without BOM
+#
+#
+# UTF-16BE-BOM
+# :   UTF-16 Big Endian with BOM
+#
+#
+# UTF-16LE
+# :   UTF-16 Little Endian without BOM
+#
+#
+# UTF-16LE-BOM
+# :   UTF-16 Little Endian with BOM
+#
+#
+# UTF-32
+# :   same as UTF-32BE
+#
+#
+# UTF-32BE
+# :   UTF-32 Big Endian without BOM
+#
+#
+# UTF-32BE-BOM
+# :   UTF-32 Big Endian with BOM
+#
+#
+# UTF-32LE
+# :   UTF-32 Little Endian without BOM
+#
+#
+# UTF-32LE-BOM
+# :   UTF-32 Little Endian with BOM
+#
+#
+# UTF8-MAC
+# :   NKDed UTF-8, a.k.a. UTF8-NFD (input only)
+#
+#
+# ### --fb-{skip, html, xml, perl, java, subchar}
+#
+# Specify the way that nkf handles unassigned characters. Without this option,
+# --fb-skip is assumed.
+#
+# ### --prefix= `escape character` `target character` ..
+#
+# When nkf converts to Shift_JIS, nkf adds a specified escape character to
+# specified 2nd byte of Shift_JIS characters. 1st byte of argument is the escape
+# character and following bytes are target characters.
+#
+# ### --no-cp932ext
+#
+# Handle the characters extended in CP932 as unassigned characters.
+#
+# ## --no-best-fit-chars
+#
+# When Unicode to Encoded byte conversion, don't convert characters which is not
+# round trip safe. When Unicode to Unicode conversion, with this and -x option,
+# nkf can be used as UTF converter. (In other words, without this and -x option,
+# nkf doesn't save some characters)
+#
+# When nkf convert string which related to path, you should use this option.
+#
+# ### --cap-input
+#
+# Decode hex encoded characters.
+#
+# ### --url-input
+#
+# Unescape percent escaped characters.
+#
+# ### --
+#
+# Ignore rest of -option.
+#
+module NKF
+  # <!--
+  #   rdoc-file=ext/nkf/nkf.c
+  #   - NKF.guess(str)  => encoding
+  # -->
+  # Returns guessed encoding of *str* by nkf routine.
+  #
+  def self.guess: (String str) -> Encoding
+
+  # <!--
+  #   rdoc-file=ext/nkf/nkf.c
+  #   - NKF.nkf(opt, str)   => string
+  # -->
+  # Convert *str* and return converted result. Conversion details are specified by
+  # *opt* as String.
+  #
+  #     require 'nkf'
+  #     output = NKF.nkf("-s", input)
+  #
+  def self.nkf: (String opt, String str) -> String
+end
+
+NKF::ASCII: Encoding
+
+NKF::AUTO: nil
+
+NKF::BINARY: Encoding
+
+NKF::EUC: Encoding
+
+NKF::JIS: Encoding
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Release date of nkf
+#
+NKF::NKF_RELEASE_DATE: String
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Gem version of nkf gem
+#
+NKF::GEM_VERSION: String
+
+NKF::NKF_VERSION: String
+
+NKF::NOCONV: nil
+
+NKF::SJIS: Encoding
+
+NKF::UNKNOWN: nil
+
+NKF::UTF16: Encoding
+
+NKF::UTF32: Encoding
+
+NKF::UTF8: Encoding
+
+# <!-- rdoc-file=ext/nkf/nkf.c -->
+# Full version string of nkf
+#
+NKF::VERSION: String

--- a/test_sig/test_helper.rb
+++ b/test_sig/test_helper.rb
@@ -1,0 +1,10 @@
+require "rbs/unit_test"
+
+module TestHelper
+  include RBS::UnitTest::TypeAssertions
+  include RBS::UnitTest::Convertibles
+
+  def self.included(base)
+    base.extend RBS::UnitTest::TypeAssertions::ClassMethods
+  end
+end

--- a/test_sig/test_kconv.rb
+++ b/test_sig/test_kconv.rb
@@ -1,0 +1,62 @@
+require "kconv"
+require "test/unit"
+require "rbs/unit_test"
+require_relative "test_helper"
+
+class KconvTest < Test::Unit::TestCase
+  include TestHelper
+  library "kconv"
+  testing "singleton(::Kconv)"
+
+  def test_guess
+    assert_send_type "(::String) -> ::Encoding",
+                     Kconv, :guess, "abc"
+  end
+
+  def test_predicates
+    assert_send_type "(::String) -> bool",
+                     Kconv, :iseuc, "abc"
+    assert_send_type "(::String) -> bool",
+                     Kconv, :isjis, "abc"
+    assert_send_type "(::String) -> bool",
+                     Kconv, :issjis, "abc"
+    assert_send_type "(::String) -> bool",
+                     Kconv, :isutf8, "abc"
+  end
+
+  def test_kconv
+    assert_send_type "(::String, ::Encoding?, ?::Encoding?) -> ::String",
+                     Kconv, :kconv, "abc", Kconv::EUC, Kconv::UTF8
+  end
+
+  def test_converters
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :toeuc, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :tojis, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :tolocale, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :tosjis, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :toutf16, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :toutf32, "abc"
+    assert_send_type "(::String) -> ::String",
+                     Kconv, :toutf8, "abc"
+  end
+
+  def test_constants
+    assert_const_type "::Encoding", "Kconv::ASCII"
+    assert_const_type "nil", "Kconv::AUTO"
+    assert_const_type "::Encoding", "Kconv::BINARY"
+    assert_const_type "::Encoding", "Kconv::EUC"
+    assert_const_type "::Encoding", "Kconv::JIS"
+    assert_const_type "nil", "Kconv::NOCONV"
+    assert_const_type "::Encoding", "Kconv::SJIS"
+    assert_const_type "nil", "Kconv::UNKNOWN"
+    assert_const_type "::Encoding", "Kconv::UTF16"
+    assert_const_type "::Encoding", "Kconv::UTF32"
+    assert_const_type "::Encoding", "Kconv::UTF8"
+  end
+end

--- a/test_sig/test_nkf.rb
+++ b/test_sig/test_nkf.rb
@@ -1,0 +1,38 @@
+require "nkf"
+require "test/unit"
+require "rbs/unit_test"
+require_relative "test_helper"
+
+class NKFTest < Test::Unit::TestCase
+  include TestHelper
+  library "nkf"
+  testing "singleton(::NKF)"
+
+  def test_guess
+    assert_send_type "(::String) -> ::Encoding",
+                     NKF, :guess, "abc"
+  end
+
+  def test_nkf
+    assert_send_type "(::String, ::String) -> ::String",
+                     NKF, :nkf, "-w", "abc"
+  end
+
+  def test_constants
+    assert_const_type "::Encoding", "NKF::ASCII"
+    assert_const_type "nil", "NKF::AUTO"
+    assert_const_type "::Encoding", "NKF::BINARY"
+    assert_const_type "::Encoding", "NKF::EUC"
+    assert_const_type "::Encoding", "NKF::JIS"
+    assert_const_type "::String", "NKF::NKF_RELEASE_DATE"
+    assert_const_type "::String", "NKF::GEM_VERSION"
+    assert_const_type "::String", "NKF::NKF_VERSION"
+    assert_const_type "nil", "NKF::NOCONV"
+    assert_const_type "::Encoding", "NKF::SJIS"
+    assert_const_type "nil", "NKF::UNKNOWN"
+    assert_const_type "::Encoding", "NKF::UTF16"
+    assert_const_type "::Encoding", "NKF::UTF32"
+    assert_const_type "::Encoding", "NKF::UTF8"
+    assert_const_type "::String", "NKF::VERSION"
+  end
+end


### PR DESCRIPTION
I propose managing the signatures in a ruby/nkf repository instead of [ruby/gem_rbs_collection](https://github.com/ruby/gem_rbs_collection).

### Background

nkf is a bundled gem.  
Until now, its signatures were managed in the RBS repository, but bundled gems are now expected to be maintained either in gem_rbs_collection or in the gem itself.

### Benefit

We can provide users with signatures that follow the Ruby code perfectly.

### Supported signatures

* kconv.rb
    * Support all methods.
* nkf.{c,rb}
    * Support all methods

### Testing of signatures

No modifications have been made to existing Ruby tests.
I have rewritten a new test for signatures.
It is sufficient to test signatures only with the latest version of Ruby.

### Comment of signatures

Ruby comments and rbs comments are synchronized using the `rake rbs:annotate` command.
After operating with [ruby/base64](https://github.com/ruby/base64), I received feedback that it's not necessary to check comment updates with CI, and that updating them at arbitrary timings seems sufficient.