### PR TITLE
Exclude unnecessary files from gem packages

### DIFF
--- a/nkf.gemspec
+++ b/nkf.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin|.github|test_sig)/}) }
   end
 
   if Gem::Platform === spec.platform and spec.platform =~ 'java' or RUBY_ENGINE == 'jruby'


### PR DESCRIPTION
Exclude development directories such as `bin`, `test_sig` and `.github` from gem packages.

### Before

```
[".git-blame-ignore-revs",
 ".github/dependabot.yml",
 ".github/workflows/sig.yml",
 ".github/workflows/test.yml",
 ".gitignore",
 "BSDL",
 "COPYING",
 "Gemfile",
 "LEGAL",
 "README.md",
 "Rakefile",
 "bin/console",
 "bin/setup",
 "ext/java/org/jruby/ext/nkf/Command.java",
 "ext/java/org/jruby/ext/nkf/CommandParser.java",
 "ext/java/org/jruby/ext/nkf/NKFLibrary.java",
 "ext/java/org/jruby/ext/nkf/Option.java",
 "ext/java/org/jruby/ext/nkf/Options.java",
 "ext/java/org/jruby/ext/nkf/RubyNKF.java",
 "ext/nkf/extconf.rb",
 "ext/nkf/nkf-utf8/config.h",
 "ext/nkf/nkf-utf8/nkf.c",
 "ext/nkf/nkf-utf8/nkf.h",
 "ext/nkf/nkf-utf8/utf8tbl.c",
 "ext/nkf/nkf-utf8/utf8tbl.h",
 "ext/nkf/nkf.c",
 "lib/kconv.rb",
 "lib/nkf.rb",
 "nkf.gemspec",
 "sig/kconv.rbs",
 "sig/nkf.rbs",
 "test_sig/test_helper.rb",
 "test_sig/test_kconv.rb",
 "test_sig/test_nkf.rb"]
```

### After

```
[".git-blame-ignore-revs",
 ".gitignore",
 "BSDL",
 "COPYING",
 "Gemfile",
 "LEGAL",
 "README.md",
 "Rakefile",
 "ext/java/org/jruby/ext/nkf/Command.java",
 "ext/java/org/jruby/ext/nkf/CommandParser.java",
 "ext/java/org/jruby/ext/nkf/NKFLibrary.java",
 "ext/java/org/jruby/ext/nkf/Option.java",
 "ext/java/org/jruby/ext/nkf/Options.java",
 "ext/java/org/jruby/ext/nkf/RubyNKF.java",
 "ext/nkf/extconf.rb",
 "ext/nkf/nkf-utf8/config.h",
 "ext/nkf/nkf-utf8/nkf.c",
 "ext/nkf/nkf-utf8/nkf.h",
 "ext/nkf/nkf-utf8/utf8tbl.c",
 "ext/nkf/nkf-utf8/utf8tbl.h",
 "ext/nkf/nkf.c",
 "lib/kconv.rb",
 "lib/nkf.rb",
 "nkf.gemspec",
 "sig/kconv.rbs",
 "sig/nkf.rbs"]
```